### PR TITLE
Allow jurisdiction_id to be an optional parameter

### DIFF
--- a/lib/open311/client/service.rb
+++ b/lib/open311/client/service.rb
@@ -11,7 +11,7 @@ module Open311
       # @example Provide a list of acceptable 311 service request types and their associated service codes
       #   Open311.service_list
       def service_list(options={})
-        options.merge!(:jurisdiction_id => jurisdiction)
+        merge_options!(options)
         response = get('services', options)
         unpack_if_xml(response) do
           response['services']['service']
@@ -27,7 +27,7 @@ module Open311
       # @example define attributes associated with a service code, i.e. 033
       #   Open311.service_definition
       def service_definition(id, options={})
-        options.merge!(:jurisdiction_id => jurisdiction)
+        merge_options!(options)
         response = get("services/#{id}", options)
         unpack_if_xml(response) do
           response['service_definition']
@@ -41,7 +41,7 @@ module Open311
       # @see http://wiki.open311.org/GeoReport_v2#GET_Service_Requests
       #   Open311.service_requests
       def service_requests(options={})
-        options.merge!(:jurisdiction_id => jurisdiction)
+        merge_options!(options)
         response = get("requests", options)
         unpack_if_xml(response) do
           response.service_requests.request.map do |request|
@@ -57,7 +57,7 @@ module Open311
       # @see http://wiki.open311.org/GeoReport_v2#POST_Service_Request
       #   Open311.post_service_request
       def post_service_request(options={})
-        options.merge!(:jurisdiction_id => jurisdiction, :api_key => api_key)
+        merge_options!(options, :api_key => api_key)
         response = post("requests", options)
         unpack_if_xml(response) do
           response['service_requests']['request']
@@ -72,7 +72,7 @@ module Open311
       # @see http://wiki.open311.org/GeoReport_v2#GET_Service_Requests
       #   Open311.get_service_request
       def get_service_request(id, options={})
-        options.merge!(:jurisdiction_id => jurisdiction)
+        merge_options!(options)
         response = get("requests/#{id}", options)
         unpack_if_xml(response) do
           response['service_requests']['request']
@@ -87,14 +87,19 @@ module Open311
       # @see http://wiki.open311.org/GeoReport_v2#GET_request_id_from_a_token
       #   Open311.request_id
       def request_id_from_token(token_id, options = {})
-        options.merge!(:jurisdiction_id => jurisdiction)
+        merge_options!(options)
         response = get("tokens/#{token_id}", options)
         unpack_if_xml(response) do
           response['service_requests']['request']
         end
       end
 
-      private 
+      private
+
+      def merge_options!(options, additional_options = {})
+        options.merge!(:jurisdiction_id => jurisdiction) if jurisdiction
+        options.merge!(additional_options)
+      end
 
       def unpack_if_xml(response)
         if format.to_s.downcase == 'xml'

--- a/spec/open311_spec.rb
+++ b/spec/open311_spec.rb
@@ -176,3 +176,22 @@ describe Open311, ".request_id_from_token" do
   end
 
 end
+
+
+describe Open311, "jurisdiction is an optional request parameter" do
+  before do
+    Open311.reset
+    Open311.configure do |config|
+      config.endpoint = 'http://311api.cityofchicago.org/open311/v2/'
+    end
+
+    stub_request(:get, 'http://311api.cityofchicago.org/open311/v2/requests/638344.xml').
+      to_return(:body => fixture('service_requests.xml'), :headers => {'Content-Type' => 'text/xml; charset=utf-8'})
+  end
+
+  it "should request the correct resource without a jurisdiction parameter" do
+    Open311.get_service_request(638344)
+    expect(a_request(:get, 'http://311api.cityofchicago.org/open311/v2/requests/638344.xml')).
+      to have_been_made
+  end
+end


### PR DESCRIPTION
Several Open311v2 API endpoints currently throw an error if you try to provide an empty jurisdiction ID (e.g. [Chicago](http://311api.cityofchicago.org/open311/v2/requests/14-01885870.xml?jurisdiction_id=)). This change allows the jurisdiction ID to be an optional parameter. Not sure if it's a spec change since this gem was implemented, but the [spec now reads](http://wiki.open311.org/GeoReport_v2#jurisdiction_id):

> #### jurisdiction_id
> 
> As a means to allow this API to distinguish multiple jurisdictions within one API endpoint we've included a "jurisdiction_id" which will be the unique identifier for cities. It has been suggested that we use the jurisdiction's main website root url (without the www) as the "jurisdiction_id". For San Francisco, the jurisdiction_id is sfgov.org. **Implementations can ignore this parameter and treat it as an "Optional Argument" if the implementation only serves one jurisdiction.**
