### PR TITLE
Fix double-wrapped service_requests

### DIFF
--- a/lib/open311/client/service.rb
+++ b/lib/open311/client/service.rb
@@ -45,10 +45,7 @@ module Open311
         response = get('requests', options)
         unpack_if_xml(response) do
           return [] unless response.service_requests.respond_to? :request
-
-          response.service_requests.request.map do |_request|
-            response['service_requests']['request']
-          end
+          response['service_requests']['request']
         end
       end
 

--- a/spec/open311_spec.rb
+++ b/spec/open311_spec.rb
@@ -89,7 +89,8 @@ describe Open311, '.service_requests' do
   it 'should return the correct results' do
     services = Open311.service_requests
     expect(services).to be_an Array
-    expect(services.first.first.service_request_id).to eq('638344')
+    expect(services.size).to eq(2)
+    expect(services.first.service_request_id).to eq('638344')
   end
 
   describe 'with no results' do


### PR DESCRIPTION
Fixes a bug in which a list of service_requests was squared. eg. `[1, 2] ---> [[1, 2], [1, 2]]` due to an unnecessary `map`.
