### PR TITLE
Accept custom http headers as api option

### DIFF
--- a/lib/open311/client/connection.rb
+++ b/lib/open311/client/connection.rb
@@ -13,6 +13,7 @@ module Open311
           proxy: proxy,
           ssl: {verify: false},
           url: endpoint,
+          headers: headers,
         }
       end
 

--- a/lib/open311/configuration.rb
+++ b/lib/open311/configuration.rb
@@ -10,6 +10,7 @@ module Open311
       :format,
       :jurisdiction,
       :proxy,
+      :headers,
       :user_agent].freeze
 
     VALID_FORMATS = [
@@ -22,6 +23,7 @@ module Open311
     DEFAULT_FORMAT       = :xml
     DEFAULT_JURISDICTION = nil
     DEFAULT_PROXY        = nil
+    DEFAULT_HEADERS      = nil
     DEFAULT_USER_AGENT   = "Open311 Ruby Gem #{Open311::Version}".freeze
 
     attr_accessor(*VALID_OPTIONS_KEYS)
@@ -46,6 +48,7 @@ module Open311
       self.jurisdiction = DEFAULT_JURISDICTION
       self.proxy        = DEFAULT_PROXY
       self.user_agent   = DEFAULT_USER_AGENT
+      self.headers      = DEFAULT_HEADERS
     end
   end
 end


### PR DESCRIPTION
This PR allows request headers to be customized, which is necessary when fetching from servers that respond to `deflate` unexpectedly. See https://github.com/lostisland/faraday/issues/120